### PR TITLE
feat: Implement MedQA Question Answering System with Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,191 @@
-# natural-language-processing-project
-Sem-2 Project for NLP
+# Medical Question Answering System using Wikipedia
+
+## Overall Objective
+
+This project aims to develop a system that can answer medical multiple-choice questions from the MedQA dataset. It leverages Wikipedia as its primary knowledge source, dynamically fetching and processing articles to find the best answer. The system is designed to utilize GPU acceleration where possible (especially for neural model inference and FAISS) and employs a vector database (FAISS) for efficient information retrieval.
+
+## Features
+
+*   Processes questions from the MedQA dataset (JSONL format).
+*   Uses Wikipedia as a dynamic, external knowledge source.
+*   Leverages Sentence-Transformers ("all-MiniLM-L6-v2") for generating high-quality semantic embeddings of questions and text passages.
+*   Employs FAISS (Facebook AI Similarity Search) for efficient similarity search in a vector database of text segments (supports both CPU and GPU versions).
+*   Utilizes SciSpacy ("en_core_sci_sm") for Named Entity Recognition (NER) tailored for biomedical text.
+*   Supports GPU acceleration for PyTorch model inference (CUDA) and FAISS indexing/searching.
+*   Modular design, with distinct Python modules for different stages of the QA pipeline.
+*   Includes unit tests for core components to ensure reliability.
+*   Comprehensive logging throughout the pipeline.
+
+## Directory Structure
+
+```
+.
+├── main.py                 # Main script to run the QA pipeline
+├── src/                    # Contains all core Python modules
+│   ├── __init__.py
+│   ├── data_loader.py          # Handles MedQA dataset loading
+│   ├── question_processor.py   # Processes questions (NER, embedding)
+│   ├── wikipedia_selector.py   # Selects and fetches Wikipedia articles
+│   ├── evidence_scorer.py      # Segments evidence, builds FAISS index, scores options
+│   ├── answer_selector.py      # Selects the final answer based on scores
+│   ├── distilbert_classifier.py # Placeholder for question classification model
+│   └── distilbert_nli.py       # Placeholder for NLI-based scoring model
+├── data/                   # Intended for dataset files (e.g., MedQA). Needs to be created by the user.
+│   └── (example: medqa_usmle.jsonl)
+├── tests/                  # Contains unit tests
+│   ├── __init__.py
+│   ├── common.py
+│   ├── test_data_loader.py
+│   ├── test_question_processor.py
+│   ├── test_wikipedia_selector.py (Placeholder - not yet implemented)
+│   ├── test_evidence_scorer.py
+│   └── test_answer_selector.py
+├── requirements.txt        # (Optional - can be generated via pip freeze > requirements.txt)
+└── README.md               # This file
+```
+
+## Setup Instructions
+
+### Prerequisites
+*   Python 3.8+
+*   Access to a terminal or command prompt.
+*   Git (for cloning the repository).
+
+### 1. Clone Repository
+```bash
+git clone <repository_url> # Replace <repository_url> with the actual URL
+cd <repository_directory_name>
+```
+
+### 2. Create a Virtual Environment (Recommended)
+```bash
+python -m venv venv
+source venv/bin/activate  # On Linux/macOS
+# For Windows:
+# venv\Scripts\activate
+```
+
+### 3. Install Dependencies
+Install PyTorch first, as its installation can be system-specific (CPU-only or specific CUDA versions).
+```bash
+# Refer to https://pytorch.org/get-started/locally/ for the correct command for your system
+pip install torch torchvision torchaudio
+```
+
+Then, install other Python packages:
+```bash
+pip install transformers sentence-transformers
+pip install spacy
+python -m spacy download en_core_sci_sm
+pip install wikipedia beautifulsoup4 requests scikit-learn nltk
+```
+
+Finally, install FAISS. Choose one of the following options based on your system:
+
+**Option 1: FAISS with GPU support (Recommended if CUDA is available)**
+```bash
+# Ensure you have a compatible NVIDIA driver and CUDA toolkit installed.
+# Check the FAISS GitHub repository for specific CUDA version compatibility.
+# Example for CUDA 11.x (might vary):
+# pip install faiss-gpu-cuda11X 
+pip install faiss-gpu # Or the specific wheel for your CUDA version
+```
+*Note: You might need to install FAISS from a specific wheel or build from source depending on your CUDA version. Consult the [official FAISS documentation/GitHub](https://github.com/facebookresearch/faiss/blob/main/INSTALL.md).*
+
+**Option 2: FAISS with CPU support**
+```bash
+pip install faiss-cpu
+```
+
+## Dataset (MedQA)
+
+This system is designed to work with the MedQA dataset.
+*   You will need to obtain the dataset (e.g., from the official MedQA repository/website or the source where it was provided).
+*   The dataset should be in **JSONL (JSON Lines)** format, where each line is a valid JSON object representing a question.
+*   Create a `data/` directory in the project root if it doesn't exist.
+*   Place your MedQA JSONL file (e.g., `medqa_usmle.jsonl`, `dev.jsonl`, `test.jsonl`) into this `data/` directory.
+
+Each JSON object (line) in the file should conform to the following structure:
+```json
+{
+  "id": "some_unique_id", // Optional, but useful for tracking
+  "question": "What is the primary cause of Type 1 Diabetes Mellitus?",
+  "options": {
+    "A": "Viral infection",
+    "B": "Insulin resistance",
+    "C": "Autoimmune destruction of beta cells",
+    "D": "Obesity"
+  },
+  "answer_idx": "C", // The key corresponding to the correct option in the "options" dictionary
+  "metamap_phrases": ["Type 1 Diabetes Mellitus", "Primary Cause"] // Optional, list of relevant medical concepts
+}
+```
+*   `question`: (string) The medical question.
+*   `options`: (dict) A dictionary where keys are option letters (e.g., 'A', 'B', 'C', 'D') and values are the corresponding option texts (string).
+*   `answer_idx`: (string) The key from the `options` dictionary that represents the correct answer.
+*   `metamap_phrases`: (list of strings, optional) Pre-extracted medical concepts related to the question. If not present, the system will rely solely on NER.
+
+## Running the System
+
+The main script `main.py` is used to run the entire question-answering pipeline.
+
+### Command-line Arguments:
+
+*   `dataset_file_path` (Required, positional): Path to the MedQA JSONL dataset file.
+    *   Example: `data/medqa_usmle.jsonl`
+*   `--subset_1000` (Optional, flag): If provided, the system will only process the first 1000 questions from the dataset.
+    *   Default: Processes all questions.
+*   `--max_wiki_pages` (Optional, integer): Maximum number of Wikipedia pages to retrieve and process for each question.
+    *   Default: `5`
+*   `--faiss_top_k` (Optional, integer): The number of top relevant evidence sentences/segments to retrieve from the FAISS index for each question option during scoring.
+    *   Default: `1` (as per the `evidence_scorer.py` default) but `main.py` default is currently also 1. *The default in `main.py` is 5, this was updated later.*
+
+### Example Usage:
+
+1.  **Run with a specific dataset file (processing all questions):**
+    ```bash
+    python main.py data/your_medqa_file.jsonl
+    ```
+
+2.  **Run with a subset of 1000 questions:**
+    ```bash
+    python main.py data/your_medqa_file.jsonl --subset_1000
+    ```
+
+3.  **Specify the number of Wikipedia pages and FAISS top K evidence segments:**
+    ```bash
+    python main.py data/your_medqa_file.jsonl --max_wiki_pages 3 --faiss_top_k 3
+    ```
+
+## Output
+
+*   The system logs its progress extensively to the console. Log messages include information about data loading, model initialization, processing steps for each question, and any warnings or errors encountered.
+*   For each question, it logs:
+    *   The question ID (if available, otherwise an index).
+    *   The scores calculated for each option.
+    *   The predicted answer key and the correct answer key.
+    *   Whether the prediction was CORRECT or INCORRECT.
+*   At the end of the run, the system prints and logs the overall accuracy:
+    `Overall Accuracy: X.XXXX (CorrectPredictions/TotalEvaluatedQuestions)`
+
+## Running Tests
+
+Unit tests are provided in the `tests/` directory to verify the functionality of individual modules.
+
+To run all tests:
+```bash
+python -m unittest discover -s tests -p "test_*.py"
+```
+This command will discover and run all files in the `tests` directory that start with `test_` and end with `.py`.
+
+## Placeholders / Future Work
+
+*   **Advanced Models**: The modules `src/distilbert_classifier.py` and `src/distilbert_nli.py` are currently placeholders. Future work could involve implementing these to:
+    *   Fine-tune a DistilBERT model for question categorization (e.g., to adapt the retrieval strategy).
+    *   Fine-tune a DistilBERT model for Natural Language Inference (NLI) to score the entailment between retrieved evidence and question-option pairs, potentially providing a more robust scoring mechanism.
+*   **Error Analysis**: More detailed error analysis and logging of specific failure cases for incorrect predictions.
+*   **Knowledge Source Expansion**: Integrating other knowledge sources beyond Wikipedia.
+*   **Hybrid Retrieval**: Combining sparse retrieval (e.g., TF-IDF/BM25) with dense retrieval (FAISS) for candidate evidence selection.
+*   **Answer Justification**: Extracting or generating justifications for the predicted answers.
+*   **Configuration File**: Moving model names, default parameters, etc., to a configuration file.
+```

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure the "data" directory is tracked by Git.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,171 @@
+import torch
+import argparse
+import logging
+import spacy
+from sentence_transformers import SentenceTransformer
+
+# Import custom modules
+from src.data_loader import load_medqa_data
+from src.question_processor import process_question
+from src.wikipedia_selector import select_wikipedia_pages
+from src.evidence_scorer import score_options_similarity_with_vector_db
+from src.answer_selector import select_answer
+# Optional: Placeholder imports for future fine-tuning steps
+# from src.distilbert_classifier import fine_tune_distilbert_classifier
+# from src.distilbert_nli import fine_tune_distilbert_nli
+
+# --- Logging Setup ---
+# BasicConfig should be called only once, preferably at the very start of your application.
+# The format now includes %(name)s for the logger name.
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def main():
+    # --- Device Selection (already in the original template but good to confirm) ---
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info(f"Using device: {device}")
+
+    # --- Command-line Argument Parsing ---
+    parser = argparse.ArgumentParser(description="MedQA Question Answering Pipeline.")
+    parser.add_argument("dataset_file_path", help="Path to the MedQA dataset file (JSONL format).")
+    parser.add_argument("--subset_1000", action="store_true", help="Use only a subset of 1000 samples from the dataset.")
+    parser.add_argument("--max_wiki_pages", type=int, default=5, help="Maximum number of Wikipedia pages to retrieve per question.")
+    parser.add_argument("--faiss_top_k", type=int, default=1, help="Top K evidence sentences to consider from FAISS search for scoring.")
+    # Add arguments for model paths if they were being loaded instead of downloaded, or for fine-tuning triggers
+    # parser.add_argument("--scispaCy_model_name", type=str, default="en_core_sci_sm", help="Name of the SciSpacy model to load.")
+    # parser.add_argument("--sentence_transformer_model_name", type=str, default="all-MiniLM-L6-v2", help="Name of the Sentence Transformer model.")
+
+    args = parser.parse_args()
+    logger.info(f"Dataset file path: {args.dataset_file_path}")
+    logger.info(f"Subset 1000: {args.subset_1000}")
+    logger.info(f"Max Wikipedia pages per question: {args.max_wiki_pages}")
+    logger.info(f"FAISS top K for evidence: {args.faiss_top_k}")
+
+    # --- Model Initialization ---
+    try:
+        logger.info("Loading SciSpacy model 'en_core_sci_sm'...")
+        nlp_spacy = spacy.load("en_core_sci_sm")
+        logger.info("SciSpacy model loaded successfully.")
+    except OSError as e:
+        logger.critical(f"Failed to load SciSpacy model 'en_core_sci_sm'. Error: {e}", exc_info=True)
+        logger.critical("Please ensure 'en_core_sci_sm' is installed (e.g., python -m spacy download en_core_sci_sm). Exiting.")
+        return # Exit if essential models fail to load
+
+    try:
+        logger.info("Loading Sentence Transformer model 'all-MiniLM-L6-v2'...")
+        sentence_model = SentenceTransformer("all-MiniLM-L6-v2")
+        sentence_model.to(device) # Move model to the selected device
+        logger.info(f"Sentence Transformer model loaded successfully and moved to {device}.")
+    except Exception as e:
+        logger.critical(f"Failed to load or move Sentence Transformer model. Error: {e}", exc_info=True)
+        logger.critical("Exiting application due to model loading failure.")
+        return # Exit
+
+    # --- Data Loading ---
+    logger.info(f"Loading MedQA data from: {args.dataset_file_path}")
+    medqa_questions = load_medqa_data(args.dataset_file_path)
+
+    if not medqa_questions: # load_medqa_data returns [] on error or no data
+        logger.error("No questions loaded from dataset file. Please check the file path and format. Exiting.")
+        return
+
+    num_total_questions = len(medqa_questions)
+    if args.subset_1000:
+        medqa_questions = medqa_questions[:1000]
+        logger.info(f"Using a subset of {len(medqa_questions)} questions out of {num_total_questions} total.")
+    else:
+        logger.info(f"Loaded {num_total_questions} questions in total.")
+
+    # --- Main Processing Loop ---
+    correct_predictions = 0
+    questions_actually_processed_for_accuracy = 0 # Questions for which an answer was attempted
+    questions_skipped_due_to_missing_answer_idx = 0
+
+    for i, question_data in enumerate(medqa_questions):
+        question_id = question_data.get('id', f'index_{i}')
+        logger.info(f"--- Processing question {i+1}/{len(medqa_questions)} (ID: {question_id}) ---")
+        
+        actual_answer_key = question_data.get('answer_idx')
+        if actual_answer_key is None:
+            logger.warning(f"Question ID {question_id} is missing 'answer_idx'. Skipping evaluation for this question.")
+            questions_skipped_due_to_missing_answer_idx +=1
+            continue # Skip to next question if we can't evaluate it
+
+        questions_actually_processed_for_accuracy += 1
+        predicted_answer_key = None # Initialize predicted answer for this iteration
+
+        try:
+            # 1. Process Question (NER, Embeddings)
+            logger.debug(f"Question ID {question_id}: Processing with question_processor...")
+            processed_q = process_question(question_data, nlp_spacy, sentence_model, device)
+            if not processed_q or 'question_embedding' not in processed_q or 'extracted_entities' not in processed_q:
+                logger.warning(f"Question ID {question_id}: Failed to process (e.g., missing keys from process_question). Skipping further steps for this question.")
+                continue
+
+            # 2. Select Wikipedia Pages
+            logger.debug(f"Question ID {question_id}: Selecting Wikipedia pages based on entities: {processed_q['extracted_entities']}...")
+            wiki_pages_texts = select_wikipedia_pages(processed_q, sentence_model, device, max_pages=args.max_wiki_pages)
+            if not wiki_pages_texts:
+                logger.warning(f"Question ID {question_id}: No Wikipedia pages retrieved. Cannot score options. This will count as an incorrect prediction.")
+                continue
+
+            # 3. Score Options with Vector DB (FAISS)
+            logger.debug(f"Question ID {question_id}: Scoring options against {len(wiki_pages_texts)} Wikipedia page(s)...")
+            option_scores = score_options_similarity_with_vector_db(processed_q, wiki_pages_texts, sentence_model, device, top_k_evidence=args.faiss_top_k)
+            if not option_scores:
+                logger.warning(f"Question ID {question_id}: Option scoring returned empty. Cannot select an answer. This will count as an incorrect prediction.")
+                continue
+            logger.info(f"Question ID {question_id}: Option scores: {option_scores}")
+
+            # 4. Select Answer
+            logger.debug(f"Question ID {question_id}: Selecting best answer based on scores...")
+            predicted_answer_key = select_answer(option_scores) # This is the variable we check later
+            if predicted_answer_key is None:
+                logger.warning(f"Question ID {question_id}: Could not select an answer from scores (select_answer returned None). This will count as an incorrect prediction.")
+                # No prediction made, so it's incorrect by default for accuracy calculation
+                continue 
+            
+            logger.info(f"Question ID {question_id}: Predicted Answer Key: '{predicted_answer_key}', Correct Answer Key: '{actual_answer_key}'")
+
+            # 5. Evaluate Prediction
+            if predicted_answer_key == actual_answer_key:
+                correct_predictions += 1
+                logger.info(f"Question ID {question_id}: Prediction CORRECT.")
+            else:
+                logger.info(f"Question ID {question_id}: Prediction INCORRECT.")
+
+        except Exception: # Catch any unexpected error during a single question's processing
+            logger.exception(f"Question ID {question_id}: An unexpected error occurred during processing. This will count as an incorrect prediction.")
+            # 'continue' is implicit if this is the last part of the loop, error is logged, question is marked incorrect
+        finally:
+            logger.info(f"--- Finished processing question {i+1}/{len(medqa_questions)} (ID: {question_id}) ---")
+
+
+    # --- Evaluation ---
+    logger.info("================== Overall Results ==================")
+    logger.info(f"Total questions in dataset (or subset): {len(medqa_questions)}")
+    logger.info(f"Questions skipped due to missing 'answer_idx': {questions_skipped_due_to_missing_answer_idx}")
+    
+    if questions_actually_processed_for_accuracy > 0:
+        accuracy = correct_predictions / questions_actually_processed_for_accuracy
+        logger.info(f"Total questions evaluated for accuracy: {questions_actually_processed_for_accuracy}")
+        logger.info(f"Correct predictions: {correct_predictions}")
+        logger.info(f"Overall Accuracy: {accuracy:.4f} ({correct_predictions}/{questions_actually_processed_for_accuracy})")
+        print(f"\nOverall Accuracy: {accuracy:.4f} ({correct_predictions}/{questions_actually_processed_for_accuracy})")
+    else:
+        logger.warning("No questions were processed and evaluated for accuracy (e.g., all questions might have been skipped or the dataset was empty).")
+        print("No questions were processed and evaluated for accuracy.")
+    logger.info("===================================================")
+
+
+if __name__ == "__main__":
+    # --- Potentially trigger fine-tuning scripts here if needed ---
+    # For example, based on some arguments or conditions:
+    # if args.run_classifier_training:
+    #     logging.info("Starting DistilBERT classifier fine-tuning (placeholder)...")
+    #     fine_tune_distilbert_classifier("path/to/classifier_traindata.csv", "./models/distilbert_classifier_finetuned", device)
+    # if args.run_nli_training:
+    #     logging.info("Starting DistilBERT NLI fine-tuning (placeholder)...")
+    #     fine_tune_distilbert_nli("path/to/nli_traindata.jsonl", "./models/distilbert_nli_finetuned", device)
+    
+    main()

--- a/src/.gitkeep
+++ b/src/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure the "src" directory is tracked by Git.

--- a/src/answer_selector.py
+++ b/src/answer_selector.py
@@ -1,0 +1,63 @@
+import logging
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def select_answer(option_scores):
+    """
+    Selects the answer option with the highest score.
+
+    Parameters
+    ----------
+    option_scores : dict
+        A dictionary where keys are option identifiers (e.g., 'A', 'B')
+        and values are their corresponding scores (float).
+        Example: {'A': 0.8, 'B': 0.9, 'C': 0.75}
+
+    Returns
+    -------
+    str or None
+        The option key with the highest score (e.g., 'B').
+        Returns None if option_scores is empty, not a dictionary, or an error occurs.
+    """
+    logger.debug(f"Attempting to select answer from scores: {option_scores}")
+    if not isinstance(option_scores, dict) or not option_scores:
+        logger.warning(f"`option_scores` is empty or not a valid dictionary: {option_scores}. Cannot select an answer.")
+        return None
+
+    try:
+        # Find the option key with the maximum score
+        selected_key = max(option_scores, key=option_scores.get)
+        logger.info(f"Selected answer: '{selected_key}' with score {option_scores[selected_key]:.4f}")
+        return selected_key
+    except ValueError: # max() arg is an empty sequence
+        logger.warning(f"ValueError (likely empty option_scores though caught by initial check) for scores: {option_scores}. Cannot select answer.", exc_info=True)
+        return None
+    except Exception as e: # Catch any other unexpected error
+        logger.error(f"An unexpected error occurred while selecting the answer from scores {option_scores}: {e}", exc_info=True)
+        return None
+
+if __name__ == '__main__':
+    # BasicConfig for standalone testing
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.info("answer_selector.py executed directly for testing purposes.")
+    
+    # Example Usage
+    scores_example1 = {'A': 0.8, 'B': 0.9, 'C': 0.75}
+    logger.info(f"Scores: {scores_example1}, Selected: {select_answer(scores_example1)}") 
+
+    scores_example2 = {'X': 0.1, 'Y': 0.05, 'Z': 0.12}
+    logger.info(f"Scores: {scores_example2}, Selected: {select_answer(scores_example2)}") 
+
+    scores_example3 = {}
+    logger.info(f"Scores: {scores_example3}, Selected: {select_answer(scores_example3)}") 
+
+    scores_example4 = {'A': -0.5, 'B': -0.1, 'C': -0.8}
+    logger.info(f"Scores: {scores_example4}, Selected: {select_answer(scores_example4)}") 
+    
+    scores_example5 = None # Test invalid input type
+    logger.info(f"Scores: {scores_example5}, Selected: {select_answer(scores_example5)}")
+    
+    scores_example6 = {"OnlyOne": 1.0}
+    logger.info(f"Scores: {scores_example6}, Selected: {select_answer(scores_example6)}")

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,0 +1,59 @@
+import json
+import logging
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+# BasicConfig should be in main.py only. Modules use getLogger.
+logger = logging.getLogger(__name__)
+
+def load_medqa_data(file_path):
+    """Load MedQA data from a JSONL file.
+
+    Parameters
+    ----------
+    file_path : str
+        The path to the JSONL file containing MedQA data.
+
+    Returns
+    -------
+    list of dict
+        A list of dictionaries, where each dictionary represents a data sample.
+        Returns an empty list if the file is not found or an error occurs during parsing.
+    """
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    logging.error(f"Error decoding JSON from line: {line.strip()} - {e}")
+        logging.info(f"Successfully loaded data from {file_path}. Number of samples: {len(data)}")
+        return data
+    except FileNotFoundError:
+        logging.error(f"File not found: {file_path}")
+        return []
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while loading data from {file_path}: {e}")
+        return []
+
+if __name__ == '__main__':
+    # Example usage (optional, for testing purposes)
+    # Create a dummy data.jsonl file for testing
+    dummy_data = [
+        {"question": "What is the capital of France?", "answer": "Paris"},
+        {"question": "Who wrote Hamlet?", "answer": "Shakespeare"}
+    ]
+    dummy_file_path = "dummy_data.jsonl"
+    with open(dummy_file_path, 'w') as f:
+        for item in dummy_data:
+            f.write(json.dumps(item) + '\\n')
+
+    loaded_data = load_medqa_data(dummy_file_path)
+    if loaded_data:
+        print("Data loaded successfully (dummy data):")
+        for item in loaded_data:
+            print(item)
+
+    # Test FileNotFoundError
+    load_medqa_data("non_existent_file.jsonl")

--- a/src/distilbert_classifier.py
+++ b/src/distilbert_classifier.py
@@ -1,0 +1,100 @@
+import logging
+import torch
+# from transformers import DistilBertTokenizer, DistilBertForSequenceClassification, Trainer, TrainingArguments
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def fine_tune_distilbert_classifier(training_data_path, model_save_path, device):
+    """
+    Placeholder for fine-tuning a DistilBERT model for sequence classification.
+
+    This function is a placeholder and does not currently implement the
+    actual fine-tuning process. It outlines the steps that would be
+    involved in such an implementation.
+
+    Parameters
+    ----------
+    training_data_path : str
+        Path to the training data file (e.g., a CSV or JSON file with texts and labels).
+    model_save_path : str
+        Path where the fine-tuned model should be saved.
+    device : torch.device or str
+        The device (e.g., "cuda", "cpu", torch.device('cuda')) to use for training.
+
+    Returns
+    -------
+    None
+    """
+    logger.info(f"Attempting to call placeholder: fine_tune_distilbert_classifier for training data: {training_data_path}, save path: {model_save_path}, device: {device}")
+    logger.warning("fine_tune_distilbert_classifier is a placeholder and is not yet implemented.")
+    
+    # Main steps for actual implementation:
+    # 1. Load training data:
+    #    - Read data from `training_data_path`. This might involve pandas for CSVs or json library for JSON.
+    #    - Extract texts and corresponding labels.
+    #    - Perform any necessary preprocessing or cleaning on the texts.
+
+    # 2. Initialize DistilBERT Tokenizer and Model:
+    #    - tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
+    #    - model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased', num_labels=<number_of_classes>)
+    
+    # 3. Tokenize data:
+    #    - train_encodings = tokenizer(texts, truncation=True, padding=True, max_length=512)
+    #    - Create a PyTorch Dataset (e.g., using `torch.utils.data.Dataset`).
+
+    # 4. Move model to device:
+    #    - model.to(device)
+
+    # 5. Set up Hugging Face Trainer or PyTorch training loop:
+    #    - If using Trainer:
+    #      - training_args = TrainingArguments(
+    #          output_dir='./results',          # output directory
+    #          num_train_epochs=3,              # total number of training epochs
+    #          per_device_train_batch_size=16,  # batch size per device during training
+    #          per_device_eval_batch_size=64,   # batch size for evaluation
+    #          warmup_steps=500,                # number of warmup steps for learning rate scheduler
+    #          weight_decay=0.01,               # strength of weight decay
+    #          logging_dir='./logs',            # directory for storing logs
+    #          logging_steps=10,
+    #          evaluation_strategy="epoch",     # Or steps
+    #          # Add other necessary arguments
+    #      )
+    #      - trainer = Trainer(
+    #          model=model,                         # the instantiated 🤗 Transformers model to be trained
+    #          args=training_args,                  # training arguments, defined above
+    #          train_dataset=train_dataset,         # training dataset
+    #          # eval_dataset=eval_dataset          # evaluation dataset (optional)
+    #      )
+    #    - If using a custom PyTorch loop:
+    #      - Define optimizer (e.g., AdamW).
+    #      - Define DataLoader.
+    #      - Implement the training steps (forward pass, loss calculation, backward pass, optimizer step).
+
+    # 6. Train the model:
+    #    - If using Trainer:
+    #      - trainer.train()
+    #    - If using custom loop:
+    #      - Iterate through epochs and batches.
+
+    # 7. Save the fine-tuned model:
+    #    - model.save_pretrained(model_save_path)
+    #    - tokenizer.save_pretrained(model_save_path) # Also save the tokenizer
+
+    logger.info("Placeholder function `fine_tune_distilbert_classifier` has completed its non-operational run.")
+    return None
+
+if __name__ == '__main__':
+    # BasicConfig for standalone testing
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.info("distilbert_classifier.py executed directly for testing purposes (will only show placeholder messages).")
+    
+    dummy_device_example = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info(f"Using device: {dummy_device_example} for standalone test call.")
+    
+    fine_tune_distilbert_classifier(
+        training_data_path="dummy_classifier_train_data.csv",
+        model_save_path="./models/distilbert_classifier_finetuned_placeholder",
+        device=dummy_device_example
+    )

--- a/src/distilbert_nli.py
+++ b/src/distilbert_nli.py
@@ -1,0 +1,79 @@
+import logging
+import torch
+# from transformers import DistilBertTokenizer, DistilBertForSequenceClassification, Trainer, TrainingArguments
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def fine_tune_distilbert_nli(training_data_path, model_save_path, device):
+    """
+    Placeholder for fine-tuning a DistilBERT model for Natural Language Inference (NLI).
+
+    This function is a placeholder and does not currently implement the
+    actual fine-tuning process. It outlines the steps that would be
+    involved in such an implementation.
+
+    Parameters
+    ----------
+    training_data_path : str
+        Path to the NLI training data file (e.g., a CSV or JSONL file with
+        premise, hypothesis, and label).
+    model_save_path : str
+        Path where the fine-tuned NLI model should be saved.
+    device : torch.device or str
+        The device (e.g., "cuda", "cpu", torch.device('cuda')) to use for training.
+
+    Returns
+    -------
+    None
+    """
+    logger.info(f"Attempting to call placeholder: fine_tune_distilbert_nli for training data: {training_data_path}, save path: {model_save_path}, device: {device}")
+    logger.warning("fine_tune_distilbert_nli is a placeholder and is not yet implemented.")
+
+    # Main steps for actual implementation:
+    # 1. Load NLI training data:
+    #    - Read data from `training_data_path`. This typically involves pairs of sentences (premise, hypothesis) and a label
+    #      (e.g., 0 for entailment, 1 for neutral, 2 for contradiction).
+    #    - Handle different NLI dataset formats (e.g., SNLI, MNLI).
+
+    # 2. Initialize DistilBERT Tokenizer and Model:
+    #    - tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
+    #    - model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased', num_labels=3) # Assuming 3 labels for NLI
+
+    # 3. Tokenize data:
+    #    - NLI tasks require tokenizing sentence pairs. The tokenizer handles this by accepting two sequences.
+    #    - train_encodings = tokenizer(premises_list, hypotheses_list, truncation=True, padding=True, max_length=512)
+    #    - Create a PyTorch Dataset (e.g., using `torch.utils.data.Dataset`).
+
+    # 4. Move model to device:
+    #    - model.to(device)
+
+    # 5. Set up Hugging Face Trainer or PyTorch training loop:
+    #    - Similar to sequence classification, set up `TrainingArguments` and `Trainer` or a custom loop.
+    #    - training_args = TrainingArguments(...)
+    #    - trainer = Trainer(model=model, args=training_args, train_dataset=train_dataset, ...)
+
+    # 6. Train the model:
+    #    - trainer.train()
+
+    # 7. Save the fine-tuned model:
+    #    - model.save_pretrained(model_save_path)
+    #    - tokenizer.save_pretrained(model_save_path)
+
+    logger.info("Placeholder function `fine_tune_distilbert_nli` has completed its non-operational run.")
+    return None
+
+if __name__ == '__main__':
+    # BasicConfig for standalone testing
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.info("distilbert_nli.py executed directly for testing purposes (will only show placeholder messages).")
+    
+    dummy_device_example = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info(f"Using device: {dummy_device_example} for standalone test call.")
+        
+    fine_tune_distilbert_nli(
+        training_data_path="dummy_nli_train_data.jsonl",
+        model_save_path="./models/distilbert_nli_finetuned_placeholder",
+        device=dummy_device_example
+    )

--- a/src/evidence_scorer.py
+++ b/src/evidence_scorer.py
@@ -1,0 +1,201 @@
+import torch
+from sentence_transformers import SentenceTransformer
+import numpy as np
+import logging
+import nltk # Keep for sent_tokenize and potential download
+import faiss
+# import re # Not currently used for fallback splitting, using string.split
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Download nltk.punkt if not already available
+# This is a module-level side effect, generally okay for widely used resources like punkt.
+# Consider moving to an explicit setup script or a one-time check in main.py if preferred.
+try:
+    nltk.data.find('tokenizers/punkt')
+except nltk.downloader.DownloadError:
+    logger.info("NLTK 'punkt' tokenizer not found. Attempting to download...")
+    try:
+        nltk.download('punkt', quiet=True)
+        logger.info("'punkt' tokenizer downloaded successfully.")
+    except Exception as e_nltk_download:
+        logger.error(f"Failed to download 'punkt' tokenizer: {e_nltk_download}. sent_tokenize may not work.", exc_info=True)
+        # Application might fail later if sent_tokenize is crucial and unavailable.
+from nltk.tokenize import sent_tokenize
+
+
+def score_options_similarity_with_vector_db(processed_question, wikipedia_texts, sentence_model, device, top_k_evidence=1):
+    """
+    Scores question options against Wikipedia text segments using FAISS for similarity search.
+
+    Parameters
+    ----------
+    processed_question : dict
+        A dictionary from `question_processor.process_question`, containing at least:
+            - 'original_question_data': dict with 'question' (str), 'options' (dict of str), and 'id' (str).
+    wikipedia_texts : list of str
+        A list of strings, where each string is the text content of a Wikipedia page.
+    sentence_model : sentence_transformers.SentenceTransformer
+        A loaded SentenceTransformer model.
+    device : torch.device
+        The PyTorch device (e.g., "cuda" or "cpu").
+    top_k_evidence : int, optional
+        The number of top evidence sentences to retrieve for each option. Default is 1.
+        The score returned is the maximum similarity among these top_k sentences.
+
+    Returns
+    -------
+    dict
+        A dictionary mapping option keys (e.g., 'A', 'B') to their similarity scores.
+        Returns empty dict if errors occur or no segments are found.
+    """
+    if not processed_question or 'original_question_data' not in processed_question:
+        logging.error("Invalid `processed_question` input.")
+        return {}
+    if not wikipedia_texts:
+        logging.warning("No Wikipedia texts provided for scoring.")
+        return {key: 0.0 for key in processed_question['original_question_data'].get('options', {}).keys()}
+
+    # Text Segmentation
+    full_text = "\n\n".join(wikipedia_texts)
+    segments = sent_tokenize(full_text)
+    segments = [s.strip() for s in segments if len(s.strip().split()) >= 5] # Filter short sentences
+
+    if not segments:
+        logging.warning("No usable sentences after tokenization. Falling back to paragraph splitting.")
+        # Fallback 1: split by double newline (paragraphs)
+        segments = [s.strip() for s in full_text.split('\n\n') if len(s.strip().split()) >= 5]
+        if not segments:
+            logging.warning("Fallback to paragraph splitting yielded no segments. Using raw wikipedia_texts.")
+            # Fallback 2: use raw texts if they are substantial enough
+            segments = [s.strip() for s in wikipedia_texts if len(s.strip().split()) >= 5]
+            if not segments:
+                logging.error("No usable text segments found in Wikipedia texts.")
+                return {key: 0.0 for key in processed_question['original_question_data'].get('options', {}).keys()}
+    
+    logging.info(f"Generated {len(segments)} text segments for FAISS indexing.")
+
+    # Segment Embedding
+    try:
+        segment_embeddings = sentence_model.encode(segments, device=device, convert_to_tensor=True, batch_size=32, show_progress_bar=False)
+        if segment_embeddings.ndim == 1: # Should be 2D
+            segment_embeddings = segment_embeddings.unsqueeze(0)
+        
+        # Normalization for cosine similarity (IndexFlatIP expects normalized vectors for cosine)
+        segment_embeddings_normalized = segment_embeddings / segment_embeddings.norm(dim=1, keepdim=True)
+        segment_embeddings_np = segment_embeddings_normalized.cpu().numpy()
+    except Exception as e:
+        logging.error(f"Error generating segment embeddings: {e}")
+        return {key: 0.0 for key in processed_question['original_question_data'].get('options', {}).keys()}
+
+    if segment_embeddings_np.shape[0] == 0:
+        logging.error("Segment embeddings are empty.")
+        return {key: 0.0 for key in processed_question['original_question_data'].get('options', {}).keys()}
+
+    # FAISS Integration
+    try:
+        embedding_dim = segment_embeddings_np.shape[1]
+        index = faiss.IndexFlatIP(embedding_dim)
+
+        # GPU acceleration if available and faiss-gpu is installed
+        if device.type == 'cuda':
+            try:
+                gpu_id = int(device.index) if device.index is not None else 0
+                res = faiss.StandardGpuResources()
+                index = faiss.index_cpu_to_gpu(res, gpu_id, index)
+                logging.info(f"Using FAISS on GPU: {gpu_id}")
+            except AttributeError: # faiss might be CPU-only version
+                logging.info("FAISS GPU resources not available or faiss-gpu not installed. Using CPU.")
+            except Exception as e_gpu: # Other potential errors with GPU setup
+                logging.warning(f"Failed to move FAISS index to GPU: {e_gpu}. Using CPU.")
+        
+        index.add(segment_embeddings_np)
+    except Exception as e:
+        logging.error(f"Error initializing or adding to FAISS index: {e}")
+        return {key: 0.0 for key in processed_question['original_question_data'].get('options', {}).keys()}
+
+    # Option Scoring
+    option_scores = {}
+    original_question_text = processed_question['original_question_data']['question']
+    options_data = processed_question['original_question_data'].get('options', {})
+
+    if not options_data:
+        logging.warning("No options found in processed_question to score.")
+        return {}
+
+    for option_key, option_text in options_data.items():
+        if not isinstance(option_text, str):
+            logging.warning(f"Option '{option_key}' text is not a string: {option_text}. Assigning score 0.")
+            option_scores[option_key] = 0.0
+            continue
+
+        combined_query = f"{original_question_text} <SEP> {option_text}"
+        try:
+            query_embedding = sentence_model.encode(combined_query, device=device, convert_to_tensor=True, show_progress_bar=False)
+            if query_embedding.ndim == 1: # Ensure 2D for norm and FAISS
+                 query_embedding_normalized = query_embedding / query_embedding.norm()
+                 query_embedding_normalized = query_embedding_normalized.unsqueeze(0)
+            else: # Should not happen with single query string
+                 query_embedding_normalized = query_embedding / query_embedding.norm(dim=1, keepdim=True)
+
+            query_embedding_np = query_embedding_normalized.cpu().numpy()
+
+            # Search FAISS
+            D, I = index.search(query_embedding_np, k=min(top_k_evidence, index.ntotal)) # D=distances (similarities), I=indices
+            
+            if D is not None and D.size > 0:
+                # Score is the max similarity among the top_k retrieved sentences
+                score = np.max(D[0]) if D[0].size > 0 else 0.0
+            else:
+                score = 0.0 # No results or error
+            
+            option_scores[option_key] = float(score)
+            logging.debug(f"Option '{option_key}', Query: '{combined_query[:100]}...', Score: {score:.4f}")
+
+        except Exception as e:
+            logging.error(f"Error scoring option '{option_key}': {e}")
+            option_scores[option_key] = 0.0
+
+    return option_scores
+
+if __name__ == '__main__':
+    logging.info("evidence_scorer.py executed directly. This script is intended to be imported as a module.")
+    # Example usage (requires models, data, and FAISS installation):
+    # from sentence_transformers import SentenceTransformer
+    # dummy_processed_question = {
+    #     'original_question_data': {
+    #         'question': "What is the primary treatment for type 1 diabetes?",
+    #         'options': {
+    #             'A': "Metformin",
+    #             'B': "Insulin",
+    #             'C': "Dietary changes",
+    #             'D': "Oral hypoglycemics"
+    #         }
+    #     }
+    # }
+    # dummy_wiki_texts = [
+    #     "Insulin is essential for managing type 1 diabetes. It helps regulate blood sugar.",
+    #     "Type 1 diabetes mellitus is an autoimmune condition. The pancreas produces little to no insulin.",
+    #     "Metformin is typically used for type 2 diabetes, not type 1.",
+    #     "While diet is important, it cannot replace insulin for type 1 diabetes.",
+    #     "Some oral medications are used for type 2 diabetes."
+    # ]
+    # try:
+    #     sbert_model = SentenceTransformer('all-MiniLM-L6-v2')
+    #     current_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    #     sbert_model.to(current_device)
+        
+    #     scores = score_options_similarity_with_vector_db(dummy_processed_question, dummy_wiki_texts, sbert_model, current_device)
+    #     if scores:
+    #         print("Option Scores (dummy example):")
+    #         for option, score in scores.items():
+    #             print(f"  {option}: {score:.4f}")
+    #     else:
+    #         print("No scores returned in dummy example.")
+            
+    # except ImportError:
+    #     print("FAISS or SentenceTransformers not installed. Cannot run example.")
+    # except Exception as e:
+    #     print(f"Could not run example due to: {e}.")

--- a/src/question_processor.py
+++ b/src/question_processor.py
@@ -1,0 +1,190 @@
+import spacy
+from sentence_transformers import SentenceTransformer
+import torch
+import logging
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def process_question(question_data, nlp_spacy, sentence_model, device):
+    """
+    Processes a single question data dictionary to extract entities and generate embeddings.
+
+    Parameters
+    ----------
+    question_data : dict
+        A dictionary containing the question, options, and potentially metamap_phrases.
+        Expected keys: 'question' (str), 'options' (dict of str), 'metamap_phrases' (list of str, optional).
+    nlp_spacy : spacy.language.Language
+        A loaded SciSpacy model for Named Entity Recognition (NER).
+    sentence_model : sentence_transformers.SentenceTransformer
+        A loaded SentenceTransformer model for generating sentence embeddings.
+        This model is expected to be already on the correct `device`.
+    device : torch.device
+        The PyTorch device (e.g., "cuda" or "cpu") for tensor operations.
+
+    Returns
+    -------
+    dict or None
+        A dictionary containing:
+            - 'original_question_data': The input question_data.
+            - 'extracted_entities': A list of unique entities extracted from the question and options.
+            - 'question_embedding': A PyTorch tensor representing the sentence embedding of the question.
+        Returns None if essential keys like 'question' or 'options' are missing.
+    """
+    question_id = question_data.get('id', 'N/A') # For more informative logging
+    logger.debug(f"Processing question ID: {question_id}")
+
+    if not all(k in question_data for k in ['question', 'options']):
+        logger.error(f"Missing 'question' or 'options' in question_data for ID {question_id}. Cannot process.")
+        return None
+
+    # Extract Metamap phrases
+    metamap_phrases = question_data.get('metamap_phrases', [])
+    if not metamap_phrases:
+        logger.debug(f"No metamap_phrases found or provided in question_data for ID {question_id}.")
+    else:
+        logger.debug(f"Metamap phrases for ID {question_id}: {metamap_phrases}")
+    extracted_entities_set = set(metamap_phrases)
+
+
+    # NER on the question itself
+    question_text = question_data.get('question')
+    if not question_text or not isinstance(question_text, str):
+        logger.warning(f"Question text for ID {question_id} is empty, missing, or not a string. Skipping NER on question.")
+        cleaned_question = "" # Fallback for cleaned_question if question is missing/invalid
+    else:
+        logger.debug(f"Original question (ID {question_id}): {question_text}")
+        cleaned_question = question_text.lower() # Clean question text (simple lowercase for now)
+        try:
+            question_doc = nlp_spacy(question_text)
+            for ent in question_doc.ents:
+                extracted_entities_set.add(ent.text)
+                logger.debug(f"NER from question (ID {question_id}): '{ent.text}'")
+        except Exception as e:
+            logger.error(f"Error during NER processing of question for ID {question_id}: {e}", exc_info=True)
+
+
+    # NER on each option's value
+    options_data = question_data.get('options')
+    if isinstance(options_data, dict):
+        for option_key, option_text in options_data.items():
+            if isinstance(option_text, str):
+                if not option_text.strip():
+                    logger.debug(f"Option '{option_key}' for question ID {question_id} is an empty string, skipping NER.")
+                    continue
+                try:
+                    option_doc = nlp_spacy(option_text)
+                    for ent in option_doc.ents:
+                        extracted_entities_set.add(ent.text)
+                        logger.debug(f"NER from option '{option_key}' (ID {question_id}): '{ent.text}'")
+                except Exception as e:
+                    logger.error(f"Error during NER processing of option '{option_key}' for ID {question_id}: {e}", exc_info=True)
+            else:
+                logger.warning(f"Option '{option_key}' for question ID {question_id} text is not a string (type: '{type(option_text)}'), skipping NER for this option.")
+    else:
+        logger.warning(f"Options for question ID {question_id} are not a dictionary or missing, skipping NER on options.")
+
+
+    list_of_unique_entities = list(extracted_entities_set)
+    logger.debug(f"Extracted {len(list_of_unique_entities)} unique entities for ID {question_id}: {list_of_unique_entities}")
+
+
+    # Generate sentence embedding for the cleaned question
+    if not cleaned_question.strip():
+        logger.warning(f"Cleaned question text is empty for question ID {question_id}. Embedding will be for an empty string.")
+        # SentenceTransformer typically handles empty strings, producing some consistent embedding.
+        
+    try:
+        # Pass show_progress_bar=False if not needed, to avoid potential tqdm overhead in logs
+        question_embedding = sentence_model.encode(cleaned_question, device=device, convert_to_tensor=True, show_progress_bar=False)
+        logger.debug(f"Generated question embedding of shape {question_embedding.shape} for ID {question_id}")
+    except Exception as e:
+        logger.error(f"Error generating sentence embedding for question ID {question_id}: {e}", exc_info=True)
+        # Fallback: return None or a zero tensor if critical, or let error propagate
+        # For this structure, if encode fails and doesn't return a tensor, the dict might be ill-formed.
+        # Let's assume for now the main processing loop will catch this if it's critical.
+        # A possible safe fallback if an embedding MUST be returned:
+        # question_embedding = torch.zeros(sentence_model.get_sentence_embedding_dimension(), device=device) 
+        # However, this requires knowing the dimension. For now, we'll let it be as is.
+        # The impact of a failed embedding should be handled by the caller or main loop.
+        # If encode returns None or raises, the dict creation below might fail or contain None.
+        # The function signature says it returns a dict, so it should ideally always do so or return None if it can't fulfill the contract.
+        # Given the current structure, if encode fails and raises, the function execution stops.
+        # If it returns None, then 'question_embedding': None will be in the dict.
+        # Let's assume process_question should return None if embedding generation fails critically.
+        return None # Or handle more gracefully if a partial result is acceptable
+
+
+    # Placeholder for question categorization logic
+    # TODO: Implement question categorization (e.g., based on keywords, structure, etc.)
+    logger.debug(f"Finished processing question ID: {question_id}")
+
+    return {
+        'original_question_data': question_data,
+        'extracted_entities': list_of_unique_entities,
+        'question_embedding': question_embedding
+    }
+
+if __name__ == '__main__':
+    # This is a placeholder for example usage or testing.
+    # For actual testing, you would need to:
+    # 1. Load a spacy model: nlp = spacy.load("en_core_sci_sm") or other scispaCy model
+    # 2. Load a sentence transformer model: model = SentenceTransformer('all-MiniLM-L6-v2')
+    # 3. Set up a device: device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    # 4. Create sample question_data
+    
+    # BasicConfig for standalone testing
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.info("question_processor.py executed directly for testing purposes.")
+    
+    dummy_question_example = {
+        "id": "dummy_qp1",
+        "question": "What is the treatment for Type 2 Diabetes Mellitus?",
+        "options": {"A": "Insulin therapy", "B": "Metformin medication", "C": "Dietary changes", "D": "Physical exercise"},
+        "metamap_phrases": ["Type 2 Diabetes Mellitus", "Treatment"]
+    }
+    try:
+        logger.info("--- Running standalone example for question_processor ---")
+        
+        # Attempt to load models for the example. These are heavy dependencies for a simple module test.
+        # In a real testing scenario for this module, these would be mocked (as in test_question_processor.py)
+        try:
+            nlp_example = spacy.load("en_core_web_sm") # Using a smaller, more common model for example
+            logger.info("Loaded spacy 'en_core_web_sm' for example.")
+        except OSError:
+            logger.error("Spacy 'en_core_web_sm' not found. Please download it: python -m spacy download en_core_web_sm")
+            nlp_example = None
+
+        try:
+            model_example = SentenceTransformer('all-MiniLM-L6-v2') # A common SBERT model
+            logger.info("Loaded SentenceTransformer 'all-MiniLM-L6-v2' for example.")
+        except Exception as e_sbert:
+            logger.error(f"Could not load SentenceTransformer 'all-MiniLM-L6-v2': {e_sbert}")
+            model_example = None
+
+        current_device_example = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if model_example:
+            model_example.to(current_device_example)
+            logger.debug(f"Test models loaded on {current_device_example}")
+        
+        if nlp_example and model_example:
+            processed_q_example = process_question(dummy_question_example, nlp_example, model_example, current_device_example)
+            
+            if processed_q_example:
+                logger.info("Processed Question (Example):")
+                logger.info(f"  Original ID: {processed_q_example['original_question_data'].get('id')}")
+                logger.info(f"  Original Question: {processed_q_example['original_question_data']['question']}")
+                logger.info(f"  Entities: {processed_q_example['extracted_entities']}")
+                if 'question_embedding' in processed_q_example and processed_q_example['question_embedding'] is not None:
+                     logger.info(f"  Embedding shape: {processed_q_example['question_embedding'].shape}")
+                else:
+                     logger.warning("  Question embedding is missing or None in the result.")
+            else:
+                logger.error("Processing failed for the example question.")
+        else:
+            logger.warning("One or more models (spaCy, SentenceTransformer) could not be loaded. Skipping example run.")
+            
+    except Exception as e_main_test:
+        logger.error(f"Could not run standalone example for question_processor due to: {e_main_test}", exc_info=True)

--- a/src/wikipedia_selector.py
+++ b/src/wikipedia_selector.py
@@ -1,0 +1,201 @@
+import wikipedia
+import torch
+import logging
+import time
+# import requests # Not currently used
+# from bs4 import BeautifulSoup # Not currently used
+
+# Configure basic logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def select_wikipedia_pages(processed_question, sentence_model, device, max_pages=5):
+    """
+    Selects relevant Wikipedia page contents based on entities extracted from a processed question.
+
+    Parameters
+    ----------
+    processed_question : dict
+        A dictionary from `question_processor.process_question`, containing:
+            - 'extracted_entities': A list of unique entities.
+            - 'question_embedding': A PyTorch tensor for the question embedding.
+            - 'original_question_data': dict, containing at least 'id' for logging.
+    sentence_model : sentence_transformers.SentenceTransformer
+        A loaded SentenceTransformer model for generating sentence embeddings.
+        This model is expected to be on the correct `device`.
+    device : torch.device
+        The PyTorch device (e.g., "cuda" or "cpu") for tensor operations.
+    max_pages : int, optional
+        The maximum number of Wikipedia page contents to return, by default 5.
+
+    Returns
+    -------
+    list of str
+        A list of strings, where each string is the text content of a selected Wikipedia page.
+        Returns an empty list if no relevant pages are found or errors occur.
+    """
+    question_id = processed_question.get('original_question_data', {}).get('id', 'N/A_ws') # For logging
+    logger.debug(f"Starting Wikipedia page selection for question ID: {question_id}")
+
+    if not processed_question or 'extracted_entities' not in processed_question or 'question_embedding' not in processed_question:
+        logger.error(f"Invalid `processed_question` input for ID {question_id}. Missing keys like 'extracted_entities' or 'question_embedding'.")
+        return []
+
+    entities = processed_question['extracted_entities']
+    question_embedding = processed_question['question_embedding']
+
+
+    if not entities:
+        logger.info(f"No entities extracted for question ID {question_id}, cannot search Wikipedia.")
+        return []
+
+    # Query Generation: Select the first 3-5 entities
+    num_queries = min(max(1, len(entities)), 5) 
+    search_queries = entities[:num_queries]
+    logger.debug(f"Using queries for Wikipedia search (ID {question_id}): {search_queries}")
+
+    # Candidate Retrieval
+    candidate_page_titles = set()
+    for query in search_queries:
+        try:
+            logger.debug(f"Searching Wikipedia for query: '{query}' (ID: {question_id})")
+            search_results = wikipedia.search(query, results=5) # Get top 5 suggestions for the query
+            for title in search_results:
+                candidate_page_titles.add(title)
+            time.sleep(0.05) # Small delay to be respectful to Wikipedia API
+        except wikipedia.exceptions.DisambiguationError as e:
+            logger.warning(f"Disambiguation error for query '{query}' (ID: {question_id}): {e}. Trying first suggestion if available.", exc_info=True)
+            if e.options: # DisambiguationError has an 'options' attribute with suggestions
+                candidate_page_titles.add(e.options[0])
+        except Exception as e: # Catch other potential wikipedia library errors
+            logger.error(f"Error searching Wikipedia for query '{query}' (ID: {question_id}): {e}", exc_info=True)
+    
+    if not candidate_page_titles:
+        logger.info(f"No candidate Wikipedia pages found from search for question ID: {question_id}")
+        return []
+    
+    logger.debug(f"Found {len(candidate_page_titles)} unique candidate page titles for ID {question_id}: {candidate_page_titles}")
+
+    # Page Ranking & Selection
+    ranked_pages = []
+    # Ensure question_embedding is 2D for cosine_similarity: [1, dim]
+    question_embedding_2d = question_embedding.unsqueeze(0) if question_embedding.ndim == 1 else question_embedding
+
+    for title in candidate_page_titles:
+        page_summary = None
+        try:
+            logger.debug(f"Fetching summary for page '{title}' (ID: {question_id})")
+            # wikipedia.summary can sometimes raise DisambiguationError or PageError
+            page_summary = wikipedia.summary(title, sentences=5) # Fetch a few sentences for summary
+            time.sleep(0.05) # Respectful delay
+
+            if not page_summary: 
+                logger.warning(f"Empty summary for page '{title}' (ID: {question_id}), skipping similarity calculation.")
+                continue
+
+            # Encode summary; ensure show_progress_bar is False for cleaner logs unless debugging that part
+            summary_embedding = sentence_model.encode(page_summary, device=device, convert_to_tensor=True, show_progress_bar=False)
+            summary_embedding_2d = summary_embedding.unsqueeze(0) if summary_embedding.ndim == 1 else summary_embedding
+            
+            # Ensure embeddings are on the same device (usually handled by sentence_model.to(device) and passing device to encode)
+            if question_embedding_2d.device != summary_embedding_2d.device:
+                 logger.warning(f"Question embedding on {question_embedding_2d.device} and summary for '{title}' on {summary_embedding_2d.device}. Moving summary to question's device for ID {question_id}.")
+                 summary_embedding_2d = summary_embedding_2d.to(question_embedding_2d.device)
+
+            similarity_score_tensor = torch.nn.functional.cosine_similarity(question_embedding_2d, summary_embedding_2d)
+            similarity_score = similarity_score_tensor.item() # Get scalar value
+            
+            ranked_pages.append((title, similarity_score, page_summary)) # Store summary for context if needed later
+            logger.debug(f"Page '{title}' (ID: {question_id}), Similarity: {similarity_score:.4f}")
+
+        except wikipedia.exceptions.PageError: # Specific page does not exist
+            logger.warning(f"Wikipedia PageError for title '{title}' (ID: {question_id}). Page may not exist. Skipping.", exc_info=True)
+        except wikipedia.exceptions.DisambiguationError as e: # Page is a disambiguation page
+            logger.warning(f"Wikipedia DisambiguationError for title '{title}' during summary fetch (ID: {question_id}): {e}. Skipping.", exc_info=True)
+        except Exception as e: # Catch other errors during summary processing or embedding
+            logger.error(f"Unexpected error processing page '{title}' for summary/ranking (ID: {question_id}): {e}", exc_info=True)
+        
+        # time.sleep(0.05) # Delay after each API call, already have one after summary
+
+    if not ranked_pages:
+        logger.info(f"No pages could be ranked (e.g., all summaries failed) for question ID: {question_id}")
+        return []
+
+    # Sort pages by similarity score in descending order
+    ranked_pages.sort(key=lambda x: x[1], reverse=True)
+    logger.debug(f"Ranked pages for ID {question_id} (top 5): {[(p[0], p[1]) for p in ranked_pages[:5]]}")
+
+
+    # Select top N unique page titles (already unique from set, but ranking might reintroduce via different search terms mapping to same canonical)
+    selected_page_titles = []
+    seen_titles_for_selection = set() # Ensure final list is unique if multiple queries led to same ranked page
+    for r_title, r_score, _ in ranked_pages: # Iterate through ranked pages
+        if r_title not in seen_titles_for_selection:
+            selected_page_titles.append(r_title)
+            seen_titles_for_selection.add(r_title)
+            if len(selected_page_titles) >= max_pages:
+                break
+    
+    logger.info(f"Selected top {len(selected_page_titles)} pages for content fetching (ID {question_id}): {selected_page_titles}")
+
+    # Content Fetching
+    page_contents = []
+    for content_title in selected_page_titles:
+        try:
+            logger.debug(f"Fetching full content for page: '{content_title}' (ID: {question_id})")
+            page_obj = wikipedia.page(content_title) # Can raise PageError or DisambiguationError
+            page_contents.append(page_obj.content)
+            logger.debug(f"Successfully fetched and stored content for page: '{content_title}' (ID: {question_id})")
+        except wikipedia.exceptions.PageError:
+            logger.warning(f"Wikipedia PageError fetching full content for '{content_title}' (ID: {question_id}). Skipping.", exc_info=True)
+        except wikipedia.exceptions.DisambiguationError as e: # Should ideally not happen if summaries were fetched for these titles
+            logger.warning(f"Wikipedia DisambiguationError fetching full content for '{content_title}' (ID: {question_id}): {e}. Skipping.", exc_info=True)
+        except Exception as e: # Other errors like connection issues
+            logger.error(f"Error fetching full content for page '{content_title}' (ID: {question_id}): {e}", exc_info=True)
+        time.sleep(0.05) # Respectful delay after each full page load
+
+    logger.info(f"Fetched content for {len(page_contents)} pages for question ID: {question_id}.")
+    return page_contents
+
+if __name__ == '__main__':
+    # This is a placeholder for example usage or testing.
+    # For actual testing, you would need:
+    # 1. A SentenceTransformer model and device.
+    # 2. A sample `processed_question` dictionary.
+    
+    # BasicConfig for standalone testing
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.info("wikipedia_selector.py executed directly for testing purposes.")
+    
+    from sentence_transformers import SentenceTransformer # Import here for standalone test
+    
+    dummy_processed_question_example = {
+        'extracted_entities': ["Type 2 Diabetes Mellitus", "Metformin", "Treatment Guidelines for Diabetes"],
+        # Simulating a 384-dim embedding, as from all-MiniLM-L6-v2
+        'question_embedding': torch.rand((384,)), 
+        'original_question_data': {'id': 'dummy_ws1'} # Added for context
+    }
+    try:
+        logger.info("--- Running standalone example for wikipedia_selector ---")
+        
+        sbert_model_example = SentenceTransformer('all-MiniLM-L6-v2')
+        current_device_example = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        sbert_model_example.to(current_device_example)
+        
+        # Ensure question embedding is on the same device as the model for the example
+        if dummy_processed_question_example['question_embedding'].device != current_device_example:
+           dummy_processed_question_example['question_embedding'] = dummy_processed_question_example['question_embedding'].to(current_device_example)
+        
+        logger.debug(f"Test models loaded on {current_device_example} for wikipedia_selector example.")
+        
+        pages_example = select_wikipedia_pages(dummy_processed_question_example, sbert_model_example, current_device_example, max_pages=2)
+        if pages_example:
+            logger.info(f"Retrieved {len(pages_example)} page contents (Example):")
+            for i_example, content_example in enumerate(pages_example):
+                logger.debug(f"--- Page {i_example+1} (first 200 chars) ---")
+                logger.debug(content_example[:200].replace('\n', ' ') + "...") # Replace newlines for cleaner log
+        else:
+            logger.info("No pages retrieved in wikipedia_selector example.")
+            
+    except Exception as e_test_main:
+        logger.error(f"Could not run wikipedia_selector example due to: {e_test_main}", exc_info=True)

--- a/tests/.gitkeep
+++ b/tests/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure the "tests" directory is tracked by Git.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the 'tests' directory as a package.

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,41 @@
+# tests/common.py
+# This file can be used for shared mock data, helper functions,
+# or common setup for tests.
+# For now, it can remain empty or include basic comments.
+
+# Example:
+# MOCK_DEVICE = "cpu"
+# def get_mock_sentence_transformer_model():
+#     # In a real scenario, you might mock the SentenceTransformer
+#     # to avoid actual model loading during unit tests.
+#     class MockSentenceTransformer:
+#         def encode(self, sentences, device, convert_to_tensor):
+#             # Return dummy embeddings
+#             import torch
+#             if isinstance(sentences, str):
+#                 return torch.rand((384,)) if convert_to_tensor else np.random.rand(384)
+#             else:
+#                 return torch.rand((len(sentences), 384)) if convert_to_tensor else np.random.rand(len(sentences), 384)
+#         def to(self, device):
+#             return self
+#     return MockSentenceTransformer()
+
+# def get_mock_spacy_model():
+#     # Mock Spacy model
+#     class MockSpacyDoc:
+#         def __init__(self, text, ents):
+#             self.text = text
+#             self.ents = [MockSpacyEnt(ent_text, ent_label) for ent_text, ent_label in ents]
+#     class MockSpacyEnt:
+#         def __init__(self, text, label_):
+#             self.text = text
+#             self.label_ = label_
+#     class MockSpacyModel:
+#         def __call__(self, text):
+#             # Simple mock: return no entities, or predefined ones based on text
+#             if "diabetes" in text.lower():
+#                 return MockSpacyDoc(text, [("diabetes", "DISEASE")])
+#             return MockSpacyDoc(text, [])
+#     return MockSpacyModel()
+
+pass

--- a/tests/test_answer_selector.py
+++ b/tests/test_answer_selector.py
@@ -1,0 +1,70 @@
+import unittest
+import logging
+from unittest.mock import patch
+
+# Adjust import path based on your project structure
+from src.answer_selector import select_answer
+
+class TestAnswerSelector(unittest.TestCase):
+
+    def test_basic_selection(self):
+        """Test basic functionality: selecting the key with the highest score."""
+        option_scores = {'A': 0.1, 'B': 0.9, 'C': 0.5}
+        self.assertEqual(select_answer(option_scores), 'B')
+
+    def test_another_basic_selection(self):
+        """Test with different scores."""
+        option_scores = {'X': 0.85, 'Y': 0.75, 'Z': 0.92}
+        self.assertEqual(select_answer(option_scores), 'Z')
+
+    def test_tie_breaking_implicit(self):
+        """Test tie-breaking (current implementation likely picks first or by dict order)."""
+        option_scores = {'A': 0.9, 'B': 0.9, 'C': 0.5}
+        # The exact behavior for ties depends on `max(dict, key=dict.get)`
+        # which typically returns the first key encountered with the max value.
+        # This can be unpredictable if dict order changes, but for testing,
+        # we can assert it's one of the tied keys.
+        result = select_answer(option_scores)
+        self.assertIn(result, ['A', 'B']) 
+
+    def test_empty_scores_dictionary(self):
+        """Test with an empty scores dictionary."""
+        option_scores = {}
+        # Based on implementation, select_answer logs a warning and returns None
+        with patch.object(logging, 'warning') as mock_log_warning:
+            self.assertIsNone(select_answer(option_scores))
+            mock_log_warning.assert_called_with("`option_scores` is empty or not a dictionary. Cannot select an answer.")
+
+    def test_scores_with_negative_values(self):
+        """Test with negative score values."""
+        option_scores = {'A': -0.5, 'B': -0.1, 'C': -0.8}
+        self.assertEqual(select_answer(option_scores), 'B')
+
+    def test_single_option(self):
+        """Test with only one option."""
+        option_scores = {'M': 0.99}
+        self.assertEqual(select_answer(option_scores), 'M')
+        
+    def test_all_scores_zero(self):
+        """Test when all scores are zero."""
+        option_scores = {'A': 0.0, 'B': 0.0, 'C': 0.0}
+        result = select_answer(option_scores)
+        self.assertIn(result, ['A', 'B', 'C']) # Similar to tie-breaking
+
+    def test_non_dictionary_input(self):
+        """Test with input that is not a dictionary."""
+        with patch.object(logging, 'warning') as mock_log_warning:
+            self.assertIsNone(select_answer(None)) # Test with None
+            mock_log_warning.assert_called_with("`option_scores` is empty or not a dictionary. Cannot select an answer.")
+        
+        with patch.object(logging, 'warning') as mock_log_warning:
+            self.assertIsNone(select_answer("not_a_dict")) # Test with a string
+            mock_log_warning.assert_called_with("`option_scores` is empty or not a dictionary. Cannot select an answer.")
+
+        with patch.object(logging, 'warning') as mock_log_warning:
+            self.assertIsNone(select_answer([('A', 0.5)])) # Test with a list of tuples
+            mock_log_warning.assert_called_with("`option_scores` is empty or not a dictionary. Cannot select an answer.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,97 @@
+import unittest
+import json
+import os
+import logging
+from unittest.mock import patch, mock_open # For mocking open and logging
+
+# Adjust import path based on your project structure.
+# If tests/ is a top-level sibling to src/, this should work.
+# If your runner is in the root and runs `python -m unittest discover tests`,
+# then `from src.data_loader import load_medqa_data` is correct.
+from src.data_loader import load_medqa_data
+
+class TestDataLoader(unittest.TestCase):
+
+    def setUp(self):
+        """Set up for test methods."""
+        self.test_file_path = "test_data.jsonl"
+        self.sample_q1 = {"id": "q1", "question": "What is q1?", "answer": "a1", "options": {"A": "oA", "B": "oB"}, "answer_idx": "A", "metamap_phrases": ["m1"]}
+        self.sample_q2 = {"id": "q2", "question": "Explain q2.", "answer": "a2", "options": {"A": "oX", "B": "oY"}, "answer_idx": "B", "metamap_phrases": ["m2", "m3"]}
+
+    def tearDown(self):
+        """Tear down after test methods."""
+        if os.path.exists(self.test_file_path):
+            os.remove(self.test_file_path)
+
+    def test_successful_load(self):
+        """Test loading a valid JSONL file."""
+        with open(self.test_file_path, 'w') as f:
+            f.write(json.dumps(self.sample_q1) + '\n')
+            f.write(json.dumps(self.sample_q2) + '\n')
+
+        loaded_data = load_medqa_data(self.test_file_path)
+        self.assertIsNotNone(loaded_data)
+        self.assertEqual(len(loaded_data), 2)
+        self.assertEqual(loaded_data[0]['question'], self.sample_q1['question'])
+        self.assertEqual(loaded_data[1]['options'], self.sample_q2['options'])
+        self.assertEqual(loaded_data[0]['metamap_phrases'], self.sample_q1['metamap_phrases'])
+
+
+    @patch('src.data_loader.logging.error') # Mock logging.error within the data_loader module
+    def test_file_not_found(self, mock_log_error):
+        """Test loading a non-existent file."""
+        non_existent_file = "no_such_file.jsonl"
+        # load_medqa_data returns [] for FileNotFoundError
+        result = load_medqa_data(non_existent_file)
+        self.assertEqual(result, [])
+        mock_log_error.assert_called_with(f"File not found: {non_existent_file}")
+
+    @patch('src.data_loader.logging.error') # Mock logging.error
+    def test_invalid_json_format(self, mock_log_error):
+        """Test loading a file with invalid JSON content."""
+        with open(self.test_file_path, 'w') as f:
+            f.write("this is not valid json\n")
+            f.write(json.dumps(self.sample_q1) + '\n') # A valid line after an invalid one
+
+        loaded_data = load_medqa_data(self.test_file_path)
+        # The current implementation of load_medqa_data tries to load line by line
+        # and logs an error for the bad line, then continues.
+        self.assertEqual(len(loaded_data), 1) # Only the valid line should be loaded
+        self.assertEqual(loaded_data[0]['question'], self.sample_q1['question'])
+        # Check that an error was logged for the invalid line
+        mock_log_error.assert_any_call(f"Error decoding JSON from line: this is not valid json - Expecting value: line 1 column 1 (char 0)")
+
+
+    @patch('src.data_loader.logging.error')
+    def test_empty_file(self, mock_log_error):
+        """Test loading an empty file."""
+        with open(self.test_file_path, 'w') as f:
+            pass # Create an empty file
+        
+        loaded_data = load_medqa_data(self.test_file_path)
+        self.assertEqual(loaded_data, [])
+        # No error should be logged for an empty file, it's a valid (though empty) case.
+        mock_log_error.assert_not_called()
+
+    @patch('src.data_loader.logging.error')
+    def test_partially_valid_json(self, mock_log_error):
+        """Test a file with some valid and some invalid JSON lines."""
+        with open(self.test_file_path, 'w') as f:
+            f.write(json.dumps(self.sample_q1) + '\n')
+            f.write("invalid json line here\n")
+            f.write(json.dumps(self.sample_q2) + '\n')
+            f.write("{'malformed': json,}\n") # another invalid json
+
+        loaded_data = load_medqa_data(self.test_file_path)
+        self.assertEqual(len(loaded_data), 2) # Should load the two valid JSON objects
+        self.assertEqual(loaded_data[0]['id'], 'q1')
+        self.assertEqual(loaded_data[1]['id'], 'q2')
+        
+        # Check that errors were logged for the invalid lines
+        self.assertEqual(mock_log_error.call_count, 2)
+        mock_log_error.assert_any_call("Error decoding JSON from line: invalid json line here - Expecting value: line 1 column 1 (char 0)")
+        mock_log_error.assert_any_call("Error decoding JSON from line: {'malformed': json,} - Expecting property name enclosed in double quotes: line 1 column 2 (char 1)")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evidence_scorer.py
+++ b/tests/test_evidence_scorer.py
@@ -1,0 +1,266 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import torch
+import numpy as np
+# import faiss # Not strictly needed as we mock the faiss module object itself
+# import nltk # Not strictly needed as we mock functions from it
+
+# Import the function to be tested
+from src.evidence_scorer import score_options_similarity_with_vector_db
+
+# Mock NLTK download if it's directly in evidence_scorer.py's global scope (it is)
+# This needs to be done before 'from src.evidence_scorer import ...' if nltk.download is at module level.
+# However, since it's inside a try-except block, we can patch it where it's used or at class/method level.
+
+class TestEvidenceScorer(unittest.TestCase):
+
+    def setUp(self):
+        """Set up common test data and mocks."""
+        self.device_cpu = torch.device("cpu")
+        self.device_cuda = torch.device("cuda") # For testing GPU path
+
+        self.sample_processed_question = {
+            'original_question_data': {
+                'question': "What is diabetes type 2?",
+                'options': {'A': "A metabolic disorder", 'B': "An infectious disease"}
+            },
+            # Dummy embedding, actual dimension from sentence_model is 384 for all-MiniLM-L6-v2
+            # For test simplicity, we'll use a smaller dimension, e.g., 3, for our dummy embeddings.
+            'question_embedding': torch.rand(1, 3) # Shape (1, embedding_dim)
+        }
+        self.embedding_dim = 3 # Must match the dummy embeddings
+
+        self.wikipedia_texts = ["Diabetes mellitus type 2 is a long-term metabolic disorder.",
+                                "It is characterized by high blood sugar, insulin resistance, and relative lack of insulin.",
+                                "Common symptoms include increased thirst, frequent urination, and unexplained weight loss."]
+
+        # Mock SentenceTransformer model
+        self.mock_sentence_model = MagicMock()
+
+        # Define a more flexible side_effect for sentence_model.encode
+        def encode_side_effect(input_texts, device, convert_to_tensor, batch_size=32, show_progress_bar=False):
+            if isinstance(input_texts, str): # Single query string
+                # For query "What is diabetes type 2? <SEP> A metabolic disorder"
+                # or "What is diabetes type 2? <SEP> An infectious disease"
+                raw_embedding = np.random.rand(self.embedding_dim).astype(np.float32)
+            elif isinstance(input_texts, list): # List of segments
+                raw_embedding = np.random.rand(len(input_texts), self.embedding_dim).astype(np.float32)
+            else:
+                raise TypeError(f"Mock encode received unexpected type: {type(input_texts)}")
+            
+            # Normalize for IndexFlatIP
+            if raw_embedding.ndim == 1:
+                norm = np.linalg.norm(raw_embedding)
+                if norm == 0: norm = 1e-12 # Avoid division by zero
+                normalized_embedding = raw_embedding / norm
+            else: # 2D
+                norms = np.linalg.norm(raw_embedding, axis=1, keepdims=True)
+                norms[norms == 0] = 1e-12 # Avoid division by zero
+                normalized_embedding = raw_embedding / norms
+
+            return torch.from_numpy(normalized_embedding).to(device) if convert_to_tensor else normalized_embedding
+
+        self.mock_sentence_model.encode.side_effect = encode_side_effect
+        
+        # Mock for faiss index instance, to be redefined in tests needing specific faiss behavior
+        self.mock_faiss_index_instance = MagicMock()
+
+
+    # Patch nltk.sent_tokenize and faiss for all tests in this class
+    @patch('src.evidence_scorer.faiss')
+    @patch('src.evidence_scorer.sent_tokenize') # sent_tokenize is imported directly
+    @patch('src.evidence_scorer.nltk.download') # To prevent actual download attempts
+    def test_successful_scoring_cpu_faiss(self, mock_nltk_download, mock_sent_tokenize, mock_faiss_module):
+        """Test successful scoring path using CPU FAISS."""
+        mock_sent_tokenize.return_value = [
+            "Diabetes mellitus type 2 is a long-term metabolic disorder.",
+            "It is characterized by high blood sugar, insulin resistance, and relative lack of insulin.",
+            "Common symptoms include increased thirst, frequent urination, and unexplained weight loss."
+        ]
+        
+        # Configure mock_faiss_module behavior
+        mock_faiss_module.IndexFlatIP.return_value = self.mock_faiss_index_instance
+        
+        # Simulate FAISS search results: (Distances, Indices)
+        # Assuming top_k_evidence=1. Score should be D[0][0]
+        # For two options, search will be called twice.
+        self.mock_faiss_index_instance.search.side_effect = [
+            (np.array([[0.95]], dtype=np.float32), np.array([[0]])), # For option A
+            (np.array([[0.88]], dtype=np.float32), np.array([[1]]))  # For option B
+        ]
+        self.mock_faiss_index_instance.ntotal = len(mock_sent_tokenize.return_value)
+
+
+        option_scores = score_options_similarity_with_vector_db(
+            self.sample_processed_question,
+            self.wikipedia_texts,
+            self.mock_sentence_model,
+            self.device_cpu
+        )
+
+        # Assertions
+        mock_nltk_download.assert_called_once_with('punkt', quiet=True) # Check if punkt download was managed
+        mock_sent_tokenize.assert_called_once_with("\n\n".join(self.wikipedia_texts))
+        
+        # Check sentence_model.encode calls
+        # 1 call for segments, 2 calls for the two options
+        self.assertEqual(self.mock_sentence_model.encode.call_count, 1 + len(self.sample_processed_question['original_question_data']['options']))
+        
+        # FAISS assertions
+        mock_faiss_module.IndexFlatIP.assert_called_once_with(self.embedding_dim)
+        self.mock_faiss_index_instance.add.assert_called_once() # Check that segment embeddings were added
+        # Check that segment embeddings passed to add are numpy and normalized
+        added_embeddings = self.mock_faiss_index_instance.add.call_args[0][0]
+        self.assertIsInstance(added_embeddings, np.ndarray)
+        # Check normalization (norms should be close to 1)
+        np.testing.assert_allclose(np.linalg.norm(added_embeddings, axis=1), 1.0, rtol=1e-5)
+
+
+        self.assertEqual(self.mock_faiss_index_instance.search.call_count, 2) # Called for each option
+
+        # Verify scores
+        self.assertIn('A', option_scores)
+        self.assertIn('B', option_scores)
+        self.assertAlmostEqual(option_scores['A'], 0.95, places=5)
+        self.assertAlmostEqual(option_scores['B'], 0.88, places=5)
+
+        # Ensure GPU resources were not called
+        mock_faiss_module.StandardGpuResources.assert_not_called()
+        mock_faiss_module.index_cpu_to_gpu.assert_not_called()
+
+
+    @patch('src.evidence_scorer.faiss')
+    @patch('src.evidence_scorer.sent_tokenize')
+    @patch('src.evidence_scorer.nltk.download')
+    def test_gpu_faiss_path(self, mock_nltk_download, mock_sent_tokenize, mock_faiss_module):
+        """Test successful scoring path using GPU FAISS (if faiss-gpu were available)."""
+        mock_sent_tokenize.return_value = ["Sentence 1 for GPU.", "Sentence 2 for GPU."]
+        
+        mock_gpu_index_instance = MagicMock()
+        mock_faiss_module.IndexFlatIP.return_value = self.mock_faiss_index_instance # CPU index first
+        mock_faiss_module.StandardGpuResources.return_value = MagicMock() # Mock GPU resources
+        mock_faiss_module.index_cpu_to_gpu.return_value = mock_gpu_index_instance # This is the index used on GPU
+
+        mock_gpu_index_instance.search.side_effect = [
+            (np.array([[0.92]], dtype=np.float32), np.array([[0]])),
+            (np.array([[0.85]], dtype=np.float32), np.array([[1]]))
+        ]
+        mock_gpu_index_instance.ntotal = len(mock_sent_tokenize.return_value)
+
+
+        option_scores = score_options_similarity_with_vector_db(
+            self.sample_processed_question,
+            self.wikipedia_texts, # Needs some text
+            self.mock_sentence_model,
+            self.device_cuda # Specify CUDA device
+        )
+
+        mock_faiss_module.StandardGpuResources.assert_called_once()
+        mock_faiss_module.index_cpu_to_gpu.assert_called_once()
+        # Ensure .add and .search were called on the GPU index instance
+        mock_gpu_index_instance.add.assert_called_once()
+        self.assertEqual(mock_gpu_index_instance.search.call_count, 2)
+        
+        self.assertAlmostEqual(option_scores['A'], 0.92, places=5)
+
+
+    @patch('src.evidence_scorer.faiss')
+    @patch('src.evidence_scorer.sent_tokenize')
+    @patch('src.evidence_scorer.nltk.download')
+    @patch('src.evidence_scorer.logging') # Mock logging module
+    def test_no_wikipedia_texts(self, mock_logging, mock_nltk_download, mock_sent_tokenize, mock_faiss_module):
+        """Test behavior when wikipedia_texts list is empty."""
+        option_scores = score_options_similarity_with_vector_db(
+            self.sample_processed_question,
+            [], # Empty list of wiki texts
+            self.mock_sentence_model,
+            self.device_cpu
+        )
+        
+        expected_scores = {key: 0.0 for key in self.sample_processed_question['original_question_data']['options']}
+        self.assertEqual(option_scores, expected_scores)
+        mock_logging.warning.assert_any_call("No Wikipedia texts provided for scoring.")
+        mock_faiss_module.IndexFlatIP.assert_not_called() # FAISS index should not be created
+
+
+    @patch('src.evidence_scorer.faiss')
+    @patch('src.evidence_scorer.sent_tokenize')
+    @patch('src.evidence_scorer.nltk.download')
+    @patch('src.evidence_scorer.logging')
+    def test_no_segments_after_tokenization(self, mock_logging, mock_nltk_download, mock_sent_tokenize, mock_faiss_module):
+        """Test behavior when sent_tokenize returns no usable segments."""
+        mock_sent_tokenize.return_value = ["short", "tiny"] # These will be filtered out
+        
+        # Mock the fallback splitting by paragraph to also return no usable segments
+        with patch('src.evidence_scorer.re.split', return_value=[]): # If re.split was used for fallback
+             # The current implementation uses full_text.split('\n\n')
+             # To mock this, we need to ensure wikipedia_texts makes full_text.split yield no segments
+             short_wiki_texts = ["word1\n\nword2"] # These parts are too short
+
+             option_scores = score_options_similarity_with_vector_db(
+                self.sample_processed_question,
+                short_wiki_texts, 
+                self.mock_sentence_model,
+                self.device_cpu
+            )
+
+        expected_scores = {key: 0.0 for key in self.sample_processed_question['original_question_data']['options']}
+        self.assertEqual(option_scores, expected_scores)
+        mock_logging.error.assert_any_call("No usable text segments found in Wikipedia texts.")
+        mock_faiss_module.IndexFlatIP.assert_not_called()
+
+    @patch('src.evidence_scorer.faiss')
+    @patch('src.evidence_scorer.sent_tokenize')
+    @patch('src.evidence_scorer.nltk.download')
+    def test_faiss_search_returns_no_results(self, mock_nltk_download, mock_sent_tokenize, mock_faiss_module):
+        """Test when FAISS search returns empty results for D."""
+        mock_sent_tokenize.return_value = ["A valid sentence for indexing."]
+        mock_faiss_module.IndexFlatIP.return_value = self.mock_faiss_index_instance
+        self.mock_faiss_index_instance.search.return_value = (np.array([[]]), np.array([[]])) # Empty D
+        self.mock_faiss_index_instance.ntotal = 1
+
+
+        option_scores = score_options_similarity_with_vector_db(
+            self.sample_processed_question,
+            self.wikipedia_texts,
+            self.mock_sentence_model,
+            self.device_cpu
+        )
+        # Expect scores to be 0.0 if no results from FAISS
+        self.assertAlmostEqual(option_scores['A'], 0.0, places=5)
+        self.assertAlmostEqual(option_scores['B'], 0.0, places=5)
+
+    @patch('src.evidence_scorer.faiss')
+    @patch('src.evidence_scorer.sent_tokenize')
+    @patch('src.evidence_scorer.nltk.download')
+    @patch('src.evidence_scorer.logging')
+    def test_option_text_not_string(self, mock_logging, mock_nltk_download, mock_sent_tokenize, mock_faiss_module):
+        """Test when an option's text is not a string."""
+        mock_sent_tokenize.return_value = ["Some evidence text."]
+        mock_faiss_module.IndexFlatIP.return_value = self.mock_faiss_index_instance
+        # Simulate search for the valid option
+        self.mock_faiss_index_instance.search.return_value = (np.array([[0.77]]), np.array([[0]]))
+        self.mock_faiss_index_instance.ntotal = 1
+
+
+        processed_q_malformed_option = {
+            'original_question_data': {
+                'question': "What is diabetes type 2?",
+                'options': {'A': 12345, 'B': "An infectious disease"} # Option A is not a string
+            },
+            'question_embedding': torch.rand(1, self.embedding_dim)
+        }
+
+        option_scores = score_options_similarity_with_vector_db(
+            processed_q_malformed_option,
+            self.wikipedia_texts,
+            self.mock_sentence_model,
+            self.device_cpu
+        )
+
+        mock_logging.warning.assert_any_call("Option 'A' text is not a string: 12345. Assigning score 0.")
+        self.assertEqual(option_scores['A'], 0.0)
+        self.assertAlmostEqual(option_scores['B'], 0.77, places=5) # Valid option should still be scored
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_question_processor.py
+++ b/tests/test_question_processor.py
@@ -1,0 +1,219 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import torch
+# import spacy # Not strictly needed as we mock the spacy model object itself
+from src.question_processor import process_question
+
+class TestQuestionProcessor(unittest.TestCase):
+
+    def setUp(self):
+        """Set up common test data and mocks."""
+        self.sample_question_data_full = {
+            "id": "q1",
+            "question": "What is Type 1 Diabetes mellitus?",
+            "options": {"A": "Condition Alpha", "B": "Condition Beta", "C": "A virus"},
+            "metamap_phrases": ["Type 1 Diabetes mellitus", "Diabetes"], # "Diabetes" is a subset, "Type 1 Diabetes mellitus" is exact
+            "answer_idx": "A"
+        }
+        self.device = torch.device("cpu")
+
+        # Mock for nlp_spacy (SciSpacy model)
+        self.mock_nlp_spacy = MagicMock()
+
+        # Mock for sentence_model (SentenceTransformer)
+        self.mock_sentence_model = MagicMock()
+        self.dummy_embedding = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5])
+        self.mock_sentence_model.encode.return_value = self.dummy_embedding
+        
+        # Define side effects for nlp_spacy mock
+        # This function will be called when mock_nlp_spacy("some text") is called
+        def nlp_side_effect(text_input):
+            doc = MagicMock()
+            doc.text = text_input # Store text for debugging if needed
+            if "What is Type 1 Diabetes mellitus?" in text_input:
+                ent1 = MagicMock()
+                ent1.text = "Type 1 Diabetes mellitus" # NER finds the full phrase
+                doc.ents = [ent1]
+            elif "Condition Alpha" in text_input:
+                ent_optA = MagicMock()
+                ent_optA.text = "Condition Alpha"
+                doc.ents = [ent_optA]
+            elif "Condition Beta" in text_input:
+                ent_optB = MagicMock()
+                ent_optB.text = "Condition Beta" # NER might find this
+                doc.ents = [ent_optB]
+            elif "A virus" in text_input: # Option C, assume NER finds "virus"
+                ent_optC = MagicMock()
+                ent_optC.text = "virus"
+                doc.ents = [ent_optC]
+            else:
+                doc.ents = [] # Default to no entities for other texts
+            return doc
+
+        self.mock_nlp_spacy.side_effect = nlp_side_effect
+
+
+    def test_successful_processing_with_mocks(self):
+        """Test normal processing with metamap phrases and NER entities."""
+        result = process_question(self.sample_question_data_full, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+
+        # Assertions for nlp_spacy calls
+        self.mock_nlp_spacy.assert_any_call(self.sample_question_data_full['question'])
+        self.mock_nlp_spacy.assert_any_call(self.sample_question_data_full['options']['A'])
+        self.mock_nlp_spacy.assert_any_call(self.sample_question_data_full['options']['B'])
+        self.mock_nlp_spacy.assert_any_call(self.sample_question_data_full['options']['C'])
+        self.assertEqual(self.mock_nlp_spacy.call_count, 1 + len(self.sample_question_data_full['options']))
+
+        # Assertion for sentence_model.encode call
+        cleaned_question_expected = self.sample_question_data_full['question'].lower()
+        self.mock_sentence_model.encode.assert_called_once_with(
+            cleaned_question_expected,
+            device=self.device,
+            convert_to_tensor=True
+        )
+
+        # Assertions for the returned dictionary structure
+        self.assertIn('original_question_data', result)
+        self.assertIn('extracted_entities', result)
+        self.assertIn('question_embedding', result)
+
+        # Verify original_question_data
+        self.assertEqual(result['original_question_data'], self.sample_question_data_full)
+
+        # Verify extracted_entities (order doesn't matter, so use sets for comparison)
+        expected_entities = {"Type 1 Diabetes mellitus", "Diabetes", "Condition Alpha", "Condition Beta", "virus"}
+        self.assertSetEqual(set(result['extracted_entities']), expected_entities)
+        
+        # Verify question_embedding
+        self.assertTrue(torch.equal(result['question_embedding'], self.dummy_embedding))
+
+    def test_handling_no_metamap_phrases(self):
+        """Test processing when 'metamap_phrases' is missing or empty."""
+        question_data_no_metamap = self.sample_question_data_full.copy()
+        del question_data_no_metamap['metamap_phrases'] # Test missing key
+
+        result = process_question(question_data_no_metamap, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+        expected_entities_from_ner = {"Type 1 Diabetes mellitus", "Condition Alpha", "Condition Beta", "virus"}
+        self.assertSetEqual(set(result['extracted_entities']), expected_entities_from_ner)
+
+        question_data_empty_metamap = self.sample_question_data_full.copy()
+        question_data_empty_metamap['metamap_phrases'] = [] # Test empty list
+        
+        # Reset call counts for mocks if necessary, or use new mocks. For simplicity, reusing.
+        self.mock_nlp_spacy.reset_mock() 
+        self.mock_sentence_model.encode.reset_mock()
+        
+        result_empty = process_question(question_data_empty_metamap, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+        self.assertSetEqual(set(result_empty['extracted_entities']), expected_entities_from_ner)
+
+
+    def test_handling_no_spacy_entities(self):
+        """Test processing when Spacy NER returns no entities."""
+        mock_nlp_no_entities = MagicMock()
+        mock_nlp_no_entities.side_effect = lambda text: MagicMock(ents=[]) # Always returns no entities
+
+        result = process_question(self.sample_question_data_full, mock_nlp_no_entities, self.mock_sentence_model, self.device)
+        
+        # Expected entities should only be from metamap_phrases
+        expected_entities_from_metamap = set(self.sample_question_data_full['metamap_phrases'])
+        self.assertSetEqual(set(result['extracted_entities']), expected_entities_from_metamap)
+        # Ensure spacy mock was called for question and options
+        self.assertEqual(mock_nlp_no_entities.call_count, 1 + len(self.sample_question_data_full['options']))
+
+
+    def test_question_cleaning_lowercase(self):
+        """Test that the question is lowercased before encoding."""
+        mixed_case_question_data = {
+            "question": "WHAT is Type 1 DIABETES Mellitus?", # Mixed case
+            "options": {"A": "Condition Alpha"},
+            "metamap_phrases": ["Type 1 Diabetes mellitus"]
+        }
+        
+        # Reset sentence_model mock to check its call argument
+        self.mock_sentence_model.encode.reset_mock()
+        # Need a spacy mock that handles the new question text
+        mock_nlp_for_mixed_case = MagicMock()
+        def nlp_side_effect_mixed(text_input):
+            doc = MagicMock()
+            if "WHAT is Type 1 DIABETES Mellitus?" in text_input:
+                doc.ents = [MagicMock(text="Type 1 DIABETES Mellitus")]
+            elif "Condition Alpha" in text_input:
+                doc.ents = [MagicMock(text="Condition Alpha")]
+            else:
+                doc.ents = []
+            return doc
+        mock_nlp_for_mixed_case.side_effect = nlp_side_effect_mixed
+
+        process_question(mixed_case_question_data, mock_nlp_for_mixed_case, self.mock_sentence_model, self.device)
+
+        expected_cleaned_question = "what is type 1 diabetes mellitus?"
+        self.mock_sentence_model.encode.assert_called_once_with(
+            expected_cleaned_question,
+            device=self.device,
+            convert_to_tensor=True
+        )
+
+    def test_missing_question_or_options_keys(self):
+        """Test behavior when 'question' or 'options' keys are missing from input."""
+        # Test missing 'question'
+        data_no_question = {"options": {"A": "Test"}, "metamap_phrases": []}
+        with patch('src.question_processor.logging.error') as mock_log_error:
+            result = process_question(data_no_question, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+            self.assertIsNone(result) # Function should return None
+            mock_log_error.assert_called_with("Missing 'question' or 'options' in question_data.")
+
+        # Test missing 'options'
+        data_no_options = {"question": "A test question?", "metamap_phrases": []}
+        with patch('src.question_processor.logging.error') as mock_log_error:
+            result = process_question(data_no_options, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+            self.assertIsNone(result) # Function should return None
+            mock_log_error.assert_called_with("Missing 'question' or 'options' in question_data.")
+
+    def test_options_not_a_dict(self):
+        """Test when 'options' is not a dictionary (e.g. a string or list)."""
+        question_data_invalid_options = {
+            "question": "What is Type 1 Diabetes mellitus?",
+            "options": "This is not a dict", # Invalid options format
+            "metamap_phrases": ["Type 1 Diabetes mellitus", "Diabetes"]
+        }
+        with patch('src.question_processor.logging.warning') as mock_log_warning:
+            result = process_question(question_data_invalid_options, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+            # NER on options should be skipped, but question processing should proceed
+            self.assertIsNotNone(result)
+            self.assertIn('extracted_entities', result)
+            expected_entities = {"Type 1 Diabetes mellitus", "Diabetes"} # Only from question NER + metamap
+            self.assertSetEqual(set(result['extracted_entities']), expected_entities)
+            mock_log_warning.assert_any_call(f"Options for question '{question_data_invalid_options['question'][:50]}...' are not a dictionary, skipping NER on options.")
+
+    def test_option_value_not_a_string(self):
+        """Test when an option's value is not a string."""
+        question_data_invalid_option_value = {
+            "question": "What is Type 1 Diabetes mellitus?",
+            "options": {"A": "Valid Option", "B": 12345}, # Option B is not a string
+            "metamap_phrases": ["Type 1 Diabetes mellitus", "Diabetes"]
+        }
+        
+        # Reset and reconfigure nlp_spacy mock for this specific test's inputs
+        self.mock_nlp_spacy.reset_mock()
+        def nlp_side_effect_specific(text_input):
+            doc = MagicMock()
+            if "What is Type 1 Diabetes mellitus?" in text_input:
+                doc.ents = [MagicMock(text="Type 1 Diabetes mellitus")]
+            elif "Valid Option" in text_input:
+                 doc.ents = [MagicMock(text="Valid Option")]
+            # No rule for 12345 as it won't be passed to spacy if it's not a string
+            else:
+                doc.ents = []
+            return doc
+        self.mock_nlp_spacy.side_effect = nlp_side_effect_specific
+
+        with patch('src.question_processor.logging.warning') as mock_log_warning:
+            result = process_question(question_data_invalid_option_value, self.mock_nlp_spacy, self.mock_sentence_model, self.device)
+            self.assertIsNotNone(result)
+            expected_entities = {"Type 1 Diabetes mellitus", "Diabetes", "Valid Option"}
+            self.assertSetEqual(set(result['extracted_entities']), expected_entities)
+            mock_log_warning.assert_any_call(f"Option 'B' for question '{question_data_invalid_option_value['question'][:50]}...' is not a string, skipping NER.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've implemented a Python-based system to answer multiple-choice medical exam questions from the MedQA dataset using Wikipedia as the sole knowledge source.

Key features:
- Loads MedQA data (JSONL format).
- Processes questions using SciSpacy for NER and Sentence-Transformers for embeddings.
- Selects up to 5 relevant Wikipedia pages per question based on entity similarity.
- Fetches Wikipedia page content and segments it into sentences/paragraphs.
- Uses FAISS (GPU or CPU) to build a vector index of Wikipedia text embeddings for each question.
- Scores answer options by generating a combined (question + option) embedding and searching the FAISS index for the most similar evidence.
- Selects the answer with the highest similarity score.
- Includes command-line options for dataset path, subset processing, max Wikipedia pages, and FAISS top K retrieval.
- GPU acceleration for Sentence-Transformers and FAISS (if available).
- Placeholder modules for future fine-tuning of DistilBERT for question classification and NLI-based scoring.
- Comprehensive logging implemented throughout the pipeline.
- Unit tests for core modules (data loading, question processing, evidence scoring, answer selection) using unittest and mocks.
- Updated README.md with setup, usage, and testing instructions.

The system is structured into modular components for clarity and maintainability. All PyTorch models and tensors are moved to the configured device (CUDA or CPU). Error handling and respectful crawling practices are included.